### PR TITLE
라우트 컴포넌트에 속성 전달

### DIFF
--- a/hello-world/Docs/Part6.md
+++ b/hello-world/Docs/Part6.md
@@ -375,3 +375,76 @@ const router = new VueRouter({
     ]
 })
 ```
+
+<br />
+
+### 라우트 컴포넌트에 속성 전달
+
+#### 개념
+
+컴포넌트에서 $route를 사용하면 특정 URL에서만 사용할 수 있는 컴포넌트의 유연성을 제한하는 라우트와 강한 결합을 만듭니다.
+
+ - $route에 의존성 추가
+
+    ```JS
+    const User = {
+        template: '<div>User {{ $router.params.id }}</div>'
+    }
+
+    const router = new VueRouter({
+        routes: [
+            {path: '/user/:id', component: User}
+        ]
+    })
+    ```
+
+ - 속성에 의존성 해제
+
+    ```JS
+    const User = {
+        props: ['id'],
+        template: '<div>User {{ id }}</div>'
+    }
+
+    const router = new VueRouter({
+        routes: [
+            { path: '/user/:id', component: User, props: true }
+        ]
+    })
+    ```
+
+    <br />
+
+    - Boolean 모드
+
+        props를 true로 설정하면 router.params가 컴포넌트 props로 설정됩니다.
+
+컴포넌트에서 $route를 사용하면 특정 URL에서만 사용할 수 있는 컴포넌트의 유연성을제한하는 라우트와 강한 결합을 만듭니다.
+
+ - 객체 모드
+
+    props가 객체일 때 컴포넌트 props가 있는 그대로 설정됩니다. props가 정적일 때 유용합니다.
+
+    ```JS
+    const router = new VueRouter({
+        routes: [
+            {path: '/promotion/from-newsletter', component, Promotion, props: { newsletterPopup: false }}
+        ]
+    })
+    ```
+
+<br />
+
+- 함수 모드
+
+    props를 반환하는 함수를 만들 수 있습니다. 이를 통해 전달인자를 다른 타입으로 캐스팅하고 적정인 값을 라우트 기반 값과 결합됩니다. '/search?q=vue'는 '{query="vue"}'를 SearchUser 컴포넌트에 전달합니다.
+
+    라우트 변경시에만 평가되므로 props 함수는 상태를 저장하지 않도록 합니다. props를 정의할 상태가 필요한 경우 래퍼 컴포넌트를 사용하면 상태가 변경될 때마다 응답할 수 있습니다.
+
+    ```JS
+    const router = new VueRouter({
+        routes: [
+            {path: '/search', component: SearchUser, props: (route) => ({ query: route.query.q })}
+        ]
+    })
+    ```

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "core-js": "^3.8.3",
     "vue": "^2.6.14",
-    "vue-router": "^2.0.0"
+    "vue-router": "^2.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",

--- a/hello-world/src/components/Product.vue
+++ b/hello-world/src/components/Product.vue
@@ -1,14 +1,18 @@
 <template>
     <div>
-        <h1>Product</h1>
-         <h2>{{ $route.params.id }}</h2>
-         <h3>{{ $route }} </h3>
+        <h1>Product {{ news }}</h1>
     </div>
 </template>
 
 <script>
 export default ({
     name: 'Product',
+    props: {
+        news: {
+            type: Boolean,
+            default: true
+        }
+    },
     data() {
         return {
 

--- a/hello-world/src/router/route.js
+++ b/hello-world/src/router/route.js
@@ -5,7 +5,7 @@ import Product from '../components/Product.vue'
 const Routes = [
     { path: '/foo', name: 'foo', component: Foo, alias: '/foofoo' },
     { path: '/bar', name: 'bar', component: Bar },
-    { path: '/product/:id', name: 'product', component: Product },
+    { path: '/product/:id', name: 'product', props: {news: false}, component: Product },
 ]
 
 export default Routes


### PR DESCRIPTION
vue-router 2.0.0에서 라우트 컴포넌트에 속성 전달하는 방식이 작동하지 않아 2.2.0으로 Version Up함.

This close #80 